### PR TITLE
Fix Naver pagination bug

### DIFF
--- a/apps/tk-capture-book/features/book/adapters/naver-book-adapter.ts
+++ b/apps/tk-capture-book/features/book/adapters/naver-book-adapter.ts
@@ -10,10 +10,13 @@ import {
 
 export class NaverBookAdapter implements BookSearchAdapter {
   async search(params: BookSearchParams): Promise<BookSearchResponse> {
+    const page = params.page ?? 1;
+    const size = params.size ?? 10;
     const naverResponse = await searchNaverBooks({
       query: params.query,
-      display: params.size,
-      start: params.page,
+      display: size,
+      // Naver API uses the starting index (1-based) rather than page number
+      start: (page - 1) * size + 1,
       sort: params.sort === "latest" ? "date" : "sim",
     });
 


### PR DESCRIPTION
## Summary
- fix the starting index calculation when requesting Naver book search results

## Testing
- `yarn test:ci` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684fd261bca0832aae41ce5f97cdbe14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pagination behavior in book search to ensure more accurate and consistent results when page or size parameters are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->